### PR TITLE
Add SSL verify disable option

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Copy this file to .env and fill in your API keys
+OPENAI_API_KEY=
+TAVILY_API_KEY=
+OPENAI_API_BASE=
+OPENAI_MODEL=
+# Set this to route requests through a proxy, e.g. "http://localhost:7890".
+HTTPS_PROXY=
+# Disable SSL certificate verification if set ("1" or "true")
+DISABLE_SSL_VERIFY=

--- a/README.md
+++ b/README.md
@@ -1,12 +1,39 @@
 # clinic_agent
 
-## changelog
+A LangChain-based research assistant specialized for clinical trial design.
 
-- [x] v0.2 develop a langchain based clinic research agent, key features list as:
-    1. use `uv` to manage the project, 
-    2. use console as interactive interface with `click` lib, 
-    3. use tavily as a tool for search pupose ,
-    4. agent behavior act as "react" agent, first rethink, and then act, 
-    5. use '.env' file to store LLM/search service configurations
-    6. refer to `prompt/clinic_agent.md` for the initial agent prompt design
-- [x] v0.1 develop a working prompt
+## Changelog
+
+- **v0.2**
+  - manage the project with `uv`
+  - provide a console interface using `click`
+  - integrate Tavily search
+  - implement a ReAct-style agent (think then act)
+  - load configuration from a `.env` file
+- configure the LLM endpoint and model via environment variables
+- optional proxy support for network access
+- disable SSL certificate verification with `DISABLE_SSL_VERIFY`
+- see `prompt/clinic_agent.md` for the initial prompt design
+- extract a PDF paper or patent to Markdown before running the agent
+- **v0.1**
+  - develop a working prompt
+
+## Usage
+
+1. Install dependencies using [`uv`](https://github.com/astral-sh/uv):
+   ```bash
+   uv pip install -r pyproject.toml
+   ```
+2. Copy `.env.example` to `.env` and fill in your API keys. You can also
+   specify `OPENAI_API_BASE`, `OPENAI_MODEL`, or `HTTPS_PROXY` for a custom
+   endpoint, model, or network proxy. Set `DISABLE_SSL_VERIFY=1` to skip
+   certificate validation if necessary.
+3. Run the agent with a question:
+   ```bash
+   clinic_agent "What are the latest trials for CAR T therapy?"
+   ```
+   Or process a PDF directly:
+   ```bash
+   clinic_agent --pdf /path/to/paper.pdf
+   ```
+   Without an argument the command enters an interactive session. Type `exit` to quit.

--- a/clinic_agent/__init__.py
+++ b/clinic_agent/__init__.py
@@ -1,0 +1,4 @@
+"""Clinic Agent package."""
+
+__all__ = ["__version__"]
+__version__ = "0.2.0"

--- a/clinic_agent/main.py
+++ b/clinic_agent/main.py
@@ -1,0 +1,85 @@
+import os
+from pathlib import Path
+from typing import Any
+
+import click
+from dotenv import load_dotenv
+from langchain.agents import AgentType, initialize_agent
+from langchain.chat_models import ChatOpenAI
+from langchain_community.tools.tavily_search import TavilySearchResults
+from pypdf import PdfReader
+
+try:  # openai is an optional dependency of langchain-openai
+    import openai
+except Exception:  # pragma: no cover - openai not installed
+    openai = None  # type: ignore
+
+
+def create_agent() -> Any:
+    """Create the LangChain agent using OpenAI chat model and Tavily search."""
+    if os.getenv("DISABLE_SSL_VERIFY"):
+        os.environ["CURL_CA_BUNDLE"] = ""
+        os.environ["REQUESTS_CA_BUNDLE"] = ""
+        if openai is not None:  # pragma: no cover - openai optional
+            openai.verify_ssl_certs = False  # type: ignore[attr-defined]
+    model = os.getenv("OPENAI_MODEL")
+    api_base = os.getenv("OPENAI_API_BASE")
+    proxy = os.getenv("HTTPS_PROXY")
+    llm_kwargs: dict[str, Any] = {"temperature": 0}
+    if model:
+        llm_kwargs["model"] = model
+    if api_base:
+        llm_kwargs["base_url"] = api_base
+    if proxy:
+        llm_kwargs["proxy"] = proxy
+    llm = ChatOpenAI(**llm_kwargs)
+    search_tool = TavilySearchResults(max_results=5)
+    tools = [search_tool]
+    return initialize_agent(
+        tools,
+        llm,
+        agent=AgentType.REACT_DOCSTORE,
+        verbose=True,
+    )
+
+
+def pdf_to_markdown(pdf_path: str) -> str:
+    """Extract text from a PDF and save it as a Markdown file."""
+    reader = PdfReader(pdf_path)
+    text = "\n\n".join(page.extract_text() or "" for page in reader.pages)
+    md_path = Path(pdf_path).with_suffix(".md")
+    md_path.write_text(text)
+    return text
+
+
+@click.command()
+@click.argument("query", required=False)
+@click.option("--pdf", "pdf_path", type=click.Path(exists=True, dir_okay=False), help="PDF file to process")
+def cli(query: str | None = None, pdf_path: str | None = None) -> None:
+    """Run the clinic agent once or enter an interactive loop."""
+    load_dotenv()
+    agent = create_agent()
+
+    if pdf_path:
+        query = pdf_to_markdown(pdf_path)
+
+    if query:
+        result = agent.run(query)
+        click.echo(result)
+        return
+
+    # Interactive loop
+    while True:
+        try:
+            user_input = click.prompt("Input", default="", show_default=False)
+        except (EOFError, KeyboardInterrupt):
+            break
+        if user_input.lower() in {"exit", "quit"}:
+            break
+        answer = agent.run(user_input)
+        click.echo(answer)
+
+
+if __name__ == "__main__":
+    cli()
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clinic_agent"
-version = "0.1.0"
+version = "0.2.0"
 description = "A langchain based clinic research agent"
 authors = ["Roo"]
 requires-python = ">=3.11"
@@ -10,6 +10,7 @@ dependencies = [
     "langchain",
     "langchain-openai",
     "python-dotenv",
+    "pypdf",
     "uv"
 ]
 


### PR DESCRIPTION
## Summary
- allow turning off SSL certificate verification via `DISABLE_SSL_VERIFY`
- document the new setting in README and `.env.example`
- apply environment variable before creating the agent

## Testing
- `python -m py_compile clinic_agent/main.py clinic_agent/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_685cc28242fc8321b03b5c177c4dcb48