### PR TITLE
Implement v0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A LangChain-based research assistant specialized for clinical trial design.
 
 ## Changelog
 
--[ ] **v0.3**
+ - [x] **v0.3**
   - create tests for the project
   - create bootstrap.sh for the project
   - make sure all the listed tests are passed

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uv sync
+uv pip install -e .
+pytest

--- a/clinic_agent/__init__.py
+++ b/clinic_agent/__init__.py
@@ -1,4 +1,4 @@
 """Clinic Agent package."""
 
 __all__ = ["__version__"]
-__version__ = "0.2.0"
+__version__ = "0.3.0"

--- a/clinic_agent/main.py
+++ b/clinic_agent/main.py
@@ -4,9 +4,10 @@ from typing import Any
 
 import click
 from dotenv import load_dotenv
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import AgentExecutor, create_react_agent
 from langchain.chat_models import ChatOpenAI
 from langchain_community.tools.tavily_search import TavilySearchResults
+from langchain_core.prompts import PromptTemplate
 from pypdf import PdfReader
 
 try:  # openai is an optional dependency of langchain-openai
@@ -22,9 +23,11 @@ def create_agent() -> Any:
         os.environ["REQUESTS_CA_BUNDLE"] = ""
         if openai is not None:  # pragma: no cover - openai optional
             openai.verify_ssl_certs = False  # type: ignore[attr-defined]
+
     model = os.getenv("OPENAI_MODEL")
     api_base = os.getenv("OPENAI_API_BASE")
     proxy = os.getenv("HTTPS_PROXY")
+
     llm_kwargs: dict[str, Any] = {"temperature": 0}
     if model:
         llm_kwargs["model"] = model
@@ -32,15 +35,31 @@ def create_agent() -> Any:
         llm_kwargs["base_url"] = api_base
     if proxy:
         llm_kwargs["proxy"] = proxy
+
     llm = ChatOpenAI(**llm_kwargs)
     search_tool = TavilySearchResults(max_results=5)
     tools = [search_tool]
-    return initialize_agent(
-        tools,
-        llm,
-        agent=AgentType.REACT_DOCSTORE,
-        verbose=True,
+
+    prompt_path = Path(__file__).parent / "prompt" / "clinic_agent.md"
+    template = (
+        prompt_path.read_text(encoding="utf-8")
+        + "\n\nYou have access to the following tools:\n{tools}\n\n"
+        + "Use the following format:\n"
+        + "Question: the input question you must answer\n"
+        + "Thought: you should always think about what to do\n"
+        + "Action: the action to take, should be one of [{tool_names}]\n"
+        + "Action Input: the input to the action\n"
+        + "Observation: the result of the action\n"
+        + "... (this Thought/Action/Action Input/Observation can repeat N times)\n"
+        + "Thought: I now know the final answer\n"
+        + "Final Answer: the final answer to the original input question\n\n"
+        + "Begin!\n\n"
+        + "Question: {input}\n"
+        + "Thought:{agent_scratchpad}"
     )
+    prompt = PromptTemplate.from_template(template)
+    agent = create_react_agent(llm, tools, prompt)
+    return AgentExecutor(agent=agent, tools=tools, verbose=True)
 
 
 def pdf_to_markdown(pdf_path: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "clinic_agent"
-version = "0.2.0"
+version = "0.3.0"
 description = "A langchain based clinic research agent"
 authors = [ { name = "Downsea", email = "qiaonancn@gmail.com" }]
 requires-python = ">=3.11"
@@ -11,7 +11,8 @@ dependencies = [
     "langchain-openai",
     "python-dotenv",
     "pypdf",
-    "uv"
+    "uv",
+    "pytest"
 ]
 
 [project.scripts]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,132 @@
+import os
+import shutil
+from pathlib import Path
+from unittest.mock import MagicMock
+import types
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Stub out heavy dependencies before importing the package
+fake_community = types.ModuleType("langchain_community")
+fake_tools = types.ModuleType("langchain_community.tools")
+fake_tavily = types.ModuleType("langchain_community.tools.tavily_search")
+fake_tavily.TavilySearchResults = MagicMock()
+fake_tools.tavily_search = fake_tavily
+fake_community.tools = fake_tools
+sys.modules["langchain_community"] = fake_community
+sys.modules["langchain_community.tools"] = fake_tools
+sys.modules["langchain_community.tools.tavily_search"] = fake_tavily
+
+fake_dotenv = types.ModuleType("dotenv")
+fake_dotenv.load_dotenv = MagicMock()
+sys.modules["dotenv"] = fake_dotenv
+
+fake_langchain = types.ModuleType("langchain")
+fake_agents = types.ModuleType("langchain.agents")
+fake_chat_models = types.ModuleType("langchain.chat_models")
+fake_agents.AgentExecutor = MagicMock()
+fake_agents.create_react_agent = MagicMock()
+fake_chat_models.ChatOpenAI = MagicMock()
+fake_langchain.agents = fake_agents
+fake_langchain.chat_models = fake_chat_models
+sys.modules["langchain"] = fake_langchain
+sys.modules["langchain.agents"] = fake_agents
+sys.modules["langchain.chat_models"] = fake_chat_models
+
+fake_langchain_core = types.ModuleType("langchain_core")
+fake_prompts = types.ModuleType("langchain_core.prompts")
+
+class DummyPrompt:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    @classmethod
+    def from_template(cls, template):
+        return cls()
+
+fake_prompts.PromptTemplate = DummyPrompt
+fake_langchain_core.prompts = fake_prompts
+sys.modules["langchain_core"] = fake_langchain_core
+sys.modules["langchain_core.prompts"] = fake_prompts
+
+fake_pypdf = types.ModuleType("pypdf")
+class DummyReader:
+    class _Page:
+        def extract_text(self):
+            return "example"
+
+    def __init__(self, path):
+        self.pages = [self._Page()]
+fake_pypdf.PdfReader = DummyReader
+sys.modules["pypdf"] = fake_pypdf
+
+import pytest
+from click.testing import CliRunner
+
+from clinic_agent.main import create_agent, pdf_to_markdown, cli
+
+
+def test_pdf_to_markdown(tmp_path):
+    src = Path('example/US11826325.pdf')
+    pdf = tmp_path / 'sample.pdf'
+    shutil.copy(src, pdf)
+    text = pdf_to_markdown(str(pdf))
+    assert (tmp_path / 'sample.md').exists()
+    assert isinstance(text, str) and text
+
+
+def test_create_agent(monkeypatch):
+    called = {}
+
+    def fake_chat_openai(**kwargs):
+        called['llm_kwargs'] = kwargs
+        return 'llm'
+
+    def fake_search_results(**kwargs):
+        called['search'] = kwargs
+        tool = MagicMock()
+        tool.name = 'search'
+        return tool
+
+    def fake_create(agent, tools, prompt):
+        called['agent'] = True
+        return 'agent'
+
+    monkeypatch.setenv('OPENAI_MODEL', 'gpt-4')
+    monkeypatch.setenv('OPENAI_API_BASE', 'https://api.test')
+    monkeypatch.setenv('HTTPS_PROXY', 'http://proxy')
+    monkeypatch.setenv('DISABLE_SSL_VERIFY', '1')
+
+    monkeypatch.setattr('clinic_agent.main.ChatOpenAI', fake_chat_openai)
+    monkeypatch.setattr('clinic_agent.main.TavilySearchResults', fake_search_results)
+    monkeypatch.setattr('clinic_agent.main.create_react_agent', lambda llm, tools, prompt: 'agent_body')
+    monkeypatch.setattr('clinic_agent.main.AgentExecutor', MagicMock(return_value='executor'))
+
+    agent = create_agent()
+    assert agent == 'executor'
+    assert called['llm_kwargs']['model'] == 'gpt-4'
+    assert called['llm_kwargs']['base_url'] == 'https://api.test'
+    assert called['llm_kwargs']['proxy'] == 'http://proxy'
+
+
+def test_cli_query(monkeypatch):
+    runner = CliRunner()
+    agent = MagicMock()
+    agent.run.return_value = 'answer'
+    monkeypatch.setattr('clinic_agent.main.create_agent', lambda: agent)
+    result = runner.invoke(cli, ['hello'])
+    assert result.exit_code == 0
+    assert 'answer' in result.output
+
+
+def test_cli_pdf(monkeypatch, tmp_path):
+    src = Path('example/US11826325.pdf')
+    pdf = tmp_path / 'input.pdf'
+    shutil.copy(src, pdf)
+    agent = MagicMock()
+    agent.run.return_value = 'pdf result'
+    monkeypatch.setattr('clinic_agent.main.create_agent', lambda: agent)
+    result = CliRunner().invoke(cli, ['--pdf', str(pdf)])
+    assert result.exit_code == 0
+    assert 'pdf result' in result.output


### PR DESCRIPTION
## Summary
- bump version to v0.3
- enhance agent creation to use local prompt
- add pytest-based test suite and bootstrap script
- document changelog for v0.3

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cea871ba88321aefd391702c59c20